### PR TITLE
Updates to add flush and border modifiers, plus code cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
-## 0.4.0 - 2015-09-28
+## 1.2.0 - 2015-09-28
 - Added `.block__flush` modifier for removing margin
   from all sides of a `.block`.
   Equivalent to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,6 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 - `bowerrc` points to `src/vendor` (the now defunct Grunt task used to do this).
 - Bumped to `1.0.0`.
->>>>>>> b4a4805f216a37d74f5083c91650f7806f8369b6
 
 
 ## 0.3.0 - 2015-01-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
+## 0.4.0 - 2015-09-28
+- Added `.block__flush` modifier for removing margin
+  from all sides of a `.block`.
+  Equivalent to
+  `.block .block__flush-top .block__flush-bottom .block__flush-sides`.
+- Changed bottom-padding of `.block__bg` to be double its current amount.
+  Ems-equivalent of 30px on top and 60px on bottom.
+- Added `.block__border-left`, `.block__border-right`, and `.block__border`
+  modifiers to control all border settings.
+
 
 ## 0.3.0 - 2015-01-16
 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "cf-layout",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "Layout helpers for Capital Framework.",
   "keywords": [
     "capital-framework",

--- a/src/cf-layout.less
+++ b/src/cf-layout.less
@@ -1327,6 +1327,7 @@
     &__flush-sides {
         margin-right: -(@grid_gutter-width / 2);
         margin-left: -(@grid_gutter-width / 2);
+
         .respond-to-min(600px, {
             margin-right: -@grid_gutter-width;
             margin-left: -@grid_gutter-width;
@@ -1350,6 +1351,7 @@
                  unit((@grid_gutter-width / 2) / @base-font-size-px, em);
         padding-bottom: unit((@grid_gutter-width * 2) / @base-font-size-px, em);
         background: @block__bg;
+
         .respond-to-min(600px, {
             padding: unit(45 / @base-font-size-px, em)
                      unit(@grid_gutter-width / @base-font-size-px, em);

--- a/src/cf-layout.less
+++ b/src/cf-layout.less
@@ -16,6 +16,9 @@
       - |
         @block__border-top
         @block__border-bottom
+        @block__border-left
+        @block__border-right
+        @block__border
         @block__bg
         @content_main-border
         @content_sidebar-bg
@@ -34,6 +37,9 @@
 // .block
 @block__border-top:             #3a8899;
 @block__border-bottom:          #3a8899;
+@block__border-left:            #3a8899;
+@block__border-right:           #3a8899;
+@block__border:                 #3a8899;
 @block__bg:                     lighten(#3a8899, 55%);
 
 // .content_main
@@ -133,9 +139,9 @@
             .content-l_col
       notes:
         - "Simplifies use of grid structure inside content containers (like .content-main)."
-        - "Since .content-l_col's are nested within .content_main extra margins will occur. 
+        - "Since .content-l_col's are nested within .content_main extra margins will occur.
            The .content-l container uses the grid_nested-col-group mixin to counter this."
-        - ".content-l_col-RATIO classes default to stacking on mobile and displaying as columns 
+        - ".content-l_col-RATIO classes default to stacking on mobile and displaying as columns
            above mobile-max width (600px). This may not be the desired breakpoint for
            all use cases, so mixins are provided to simplify changing column display to
            stacked."
@@ -213,8 +219,8 @@
       notes:
         - "Designed for use within .content_full containers."
         - "Displays .content-l_col-1-2 as columns at tablet sizes & above (600px+)"
-        - "Displays other common .content-l_col modifiers (.content-l_col-1-3, 
-           .content-l_col-2-3, .content-l_col-3-8, .content-l_col-5-8) 
+        - "Displays other common .content-l_col modifiers (.content-l_col-1-3,
+           .content-l_col-2-3, .content-l_col-3-8, .content-l_col-5-8)
            as columns above 767px."
     - name: .content-l__main modifier
       markup: |
@@ -284,11 +290,11 @@
       codenotes:
         - .content-l.content-l__main
       notes:
-        - "Designed for use in .content_main containers, which have reduced (75%) width 
+        - "Designed for use in .content_main containers, which have reduced (75%) width
            above tablet sizes to accommodate adjacent sidebar column."
         - "Displays .content-l_col-1-2 as columns in the tablet range, 600-800px;
            stacked from 800-899, the start of sidebar range; and as columns again at 900px+"
-        - "Displays other common .content-l_col modifiers (.content-l_col-1-3, .content-l_col-2-3,    
+        - "Displays other common .content-l_col modifiers (.content-l_col-1-3, .content-l_col-2-3,
            .content-l_col-3-8, .content-l_col-5-8) as columns above 900px."
     - name: .content-l__sidebar modifier
       markup: |
@@ -358,9 +364,9 @@
       codenotes:
         - .content-l.content-l__sidebar
       notes:
-        - "For use in sidebar containers, which are full width only 
+        - "For use in sidebar containers, which are full width only
            on tablet widths (600-800px)."
-        - "Displays .content-l_col-1-2 as columns in the tablet range, 
+        - "Displays .content-l_col-1-2 as columns in the tablet range,
            600-800px, and stacked at all other widths."
     - name: Large gutters modifier
       markup: |
@@ -409,14 +415,14 @@
     .respond-to-min(@tablet-min, {
         .grid_nested-col-group();
     });
-    
+
     &__full {
         .respond-to-range(@tablet-min, 767px, {
             .stack-col-thirds();
-            .stack-col-eighths(); 
+            .stack-col-eighths();
         });
     }
-    
+
     &__main {
         .respond-to-range(801px, 899px, {
             .stack-col(content-l_col-1-2);
@@ -424,13 +430,13 @@
 
         .respond-to-range(@tablet-min, 899px, {
             .stack-col-thirds();
-            .stack-col-eighths();        
+            .stack-col-eighths();
         });
     }
-    
+
     &__sidebar {
         .stack-col-thirds();
-        .stack-col-eighths();        
+        .stack-col-eighths();
 
         .respond-to-min(801px, {
             .stack-col(content-l_col-1-2);
@@ -579,18 +585,18 @@
     .content-l_col.@{col} {
         display: block;
         width: 100%;
-        
+
         &.content-l_col__before-divider {
             .grid_column__top-divider();
         }
     }
-    
+
     &.content-l__large-gutters {
         .content-l_col.@{col}.content-l_col__before-divider {
             border-left-width: @grid_gutter-width;
         }
     }
-    
+
     .content-l_col.@{col} + .content-l_col.@{col} {
         margin-top: unit(@grid_gutter-width / @base-font-size-px, em);
     }
@@ -599,7 +605,7 @@
 .stack-col-thirds() {
   .stack-col(content-l_col-1-3);
   .stack-col(content-l_col-2-3);
-  
+
   .content-l_col.content-l_col-1-3 + .content-l_col.content-l_col-2-3,
   .content-l_col.content-l_col-2-3 + .content-l_col.content-l_col-1-3 {
      margin-top: unit(@grid_gutter-width / @base-font-size-px, em);
@@ -999,6 +1005,56 @@
       notes:
         - "The standard .block class by itself simply adds a margin of twice the
            gutter width to the top and bottom."
+    - name: Border-top modifier
+      markup: |
+        Main content...
+        <div class="block block__border-top">
+            Content block with top border.
+        </div>
+      codenotes:
+        - .block.block__border-top
+      notes:
+        - "Adds top border to .block."
+    - name: Border-bottom modifier
+      markup: |
+        Main content...
+        <div class="block block__border-bottom">
+            Content block with bottom border.
+        </div>
+      codenotes:
+        - .block.block__border-bottom
+      notes:
+        - "Adds bottom border to .block."
+    - name: Border-left modifier
+      markup: |
+        Main content...
+        <div class="block block__border-left">
+            Content block with left border.
+        </div>
+      codenotes:
+        - .block.block__border-left
+      notes:
+        - "Adds left border to .block."
+    - name: Border-right modifier
+      markup: |
+        Main content...
+        <div class="block block__border-right">
+            Content block with right border.
+        </div>
+      codenotes:
+        - .block.block__border-right
+      notes:
+        - "Adds right border to .block."
+    - name: Border modifier
+      markup: |
+        Main content...
+        <div class="block block__border">
+            Content block with borders on all sides.
+        </div>
+      codenotes:
+        - .block.block__border
+      notes:
+        - "Adds border on all sides to .block."
     - name: Flush-top modifier
       markup: |
         Main content...
@@ -1046,26 +1102,56 @@
         - "Removes the side margin from .block."
         - "Typically used in conjuction with .block__bg to create a 'well' whose
            background extends into the left and right gutters. (See below.)"
-    - name: Border-top modifier
+    - name: Flush modifier
+      markup: |
+        <main class="content content__1-3" role="main">
+            <div class="content_wrapper">
+                <aside class="content_sidebar">
+                    Section navigation
+                </aside>
+                <section class="content_main">
+                    Main content...
+                    <aside class="block block__flush">
+                        Content block with no margins.
+                    </aside>
+                </section>
+            </div>
+        </main>
+      codenotes:
+        - .block.block__flush
+      notes:
+        - "Removes the side, top, and bottom margin from .block."
+    - name: Background modifier
       markup: |
         Main content...
-        <div class="block block__border-top">
-            Content block with top border.
+        <div class="block block__bg">
+            Content block with a background
         </div>
       codenotes:
-        - .block.block__border-top
+        - .block.block__bg
       notes:
-        - "Adds top border to .block."
-    - name: Border-bottom modifier
+        - "Adds a background color and padding to .block."
+        - "Setup for (ems-equivalent) 30px padding on top and 60px on bottom."
+    - name: Background and flush-sides modifier combo example
       markup: |
-        Main content...
-        <div class="block block__border-bottom">
-            Content block with bottom border.
-        </div>
+        <main class="content content__1-3" id="main" role="main">
+            <div class="content_wrapper">
+                <aside class="content_sidebar">
+                    Section navigation
+                </aside>
+                <section class="content_main content__flush-bottom">
+                    Main content...
+                    <div class="block block__flush-sides block__bg">
+                        Content block with a background and flush sides
+                    </div>
+                </section>
+            </div>
+        </main>
       codenotes:
-        - .block.block__border-bottom
+        - .block.block__flush-sides.block__bg
       notes:
-        - "Adds bottom border to .block."
+        - "This is an example of combining modifiers to get a flush padded bg
+           with a .block."
     - name: Padded-top modifier
       markup: |
         Main content...
@@ -1090,36 +1176,6 @@
       notes:
         - "Breaks bottom margin into margin & padding. Useful in combination with
            block__border-bottom to add padding between block contents & border."
-    - name: Background modifier
-      markup: |
-        Main content...
-        <div class="block block__bg">
-            Content block with a background
-        </div>
-      codenotes:
-        - .block.block__bg
-      notes:
-        - "Adds a background color and padding to .block."
-    - name: Background and flush-sides modifier combo example
-      markup: |
-        <main class="content content__1-3" id="main" role="main">
-            <div class="content_wrapper">
-                <aside class="content_sidebar">
-                    Section navigation
-                </aside>
-                <section class="content_main content__flush-bottom">
-                    Main content...
-                    <div class="block block__flush-sides block__bg">
-                        Content block with a background and flush sides
-                    </div>
-                </section>
-            </div>
-        </main>
-      codenotes:
-        - .block.block__flush-sides.block__bg
-      notes:
-        - "This is an example of combining modifiers to get a flush padded bg
-           with a .block."
     - name: Sub blocks
       markup: |
         <div class="block block__sub">
@@ -1177,13 +1233,25 @@
 .block {
     margin-top: unit((@grid_gutter-width * 2) / @base-font-size-px, em);
     margin-bottom: unit((@grid_gutter-width * 2) / @base-font-size-px, em);
-    
+
     &__border-top {
         border-top: 1px solid @block__border-top;
     }
-    
+
     &__border-bottom {
         border-bottom: 1px solid @block__border-bottom;
+    }
+
+    &__border-left {
+        border-left: 1px solid @block__border-left;
+    }
+
+    &__border-right {
+        border-right: 1px solid @block__border-right;
+    }
+
+    &__border {
+        border: 1px solid @block__border;
     }
 
     &__flush-top {
@@ -1203,16 +1271,28 @@
         });
     }
 
+    &__flush {
+        margin-top: 0 !important;
+        margin-bottom: 0 !important;
+        margin-right: -(@grid_gutter-width / 2);
+        margin-left: -(@grid_gutter-width / 2);
+        .respond-to-min(600px, {
+          margin-right: -@grid_gutter-width;
+          margin-left: -@grid_gutter-width;
+        });
+    }
+
     &__bg {
         padding: unit(@grid_gutter-width / @base-font-size-px, em)
                  unit((@grid_gutter-width / 2) / @base-font-size-px, em);
+        padding-bottom: unit((@grid_gutter-width * 2) / @base-font-size-px, em);
         background: @block__bg;
         .respond-to-min(600px, {
             padding: unit(45 / @base-font-size-px, em)
                      unit(@grid_gutter-width / @base-font-size-px, em);
         });
     }
-    
+
     &__padded-top {
         padding-top: unit(30px / @base-font-size-px, em);
         margin-top: unit(30px / @base-font-size-px, em);
@@ -1428,7 +1508,7 @@
 .grid_column__top-divider {
     margin-top: unit((@grid_gutter-width * 2) / @base-font-size-px, em);
     border-left-width: @grid_gutter-width / 2;
-    
+
     &:before {
         content: "";
         display: block;

--- a/src/cf-layout.less
+++ b/src/cf-layout.less
@@ -19,9 +19,9 @@
     codenotes:
       - |
         @block__border-top
+        @block__border-right
         @block__border-bottom
         @block__border-left
-        @block__border-right
         @block__border
         @block__bg
         @content_main-border
@@ -40,9 +40,9 @@
 
 // .block
 @block__border-top:             #3a8899;
+@block__border-right:           #3a8899;
 @block__border-bottom:          #3a8899;
 @block__border-left:            #3a8899;
-@block__border-right:           #3a8899;
 @block__border:                 #3a8899;
 @block__bg:                     lighten(#3a8899, 55%);
 
@@ -1077,6 +1077,16 @@
         - .block.block__border-top
       notes:
         - "Adds top border to .block."
+    - name: Border-right modifier
+      markup: |
+        Main content...
+        <div class="block block__border-right">
+            Content block with right border.
+        </div>
+      codenotes:
+        - .block.block__border-right
+      notes:
+        - "Adds right border to .block."
     - name: Border-bottom modifier
       markup: |
         Main content...
@@ -1097,16 +1107,6 @@
         - .block.block__border-left
       notes:
         - "Adds left border to .block."
-    - name: Border-right modifier
-      markup: |
-        Main content...
-        <div class="block block__border-right">
-            Content block with right border.
-        </div>
-      codenotes:
-        - .block.block__border-right
-      notes:
-        - "Adds right border to .block."
     - name: Border modifier
       markup: |
         Main content...
@@ -1300,16 +1300,16 @@
         border-top: 1px solid @block__border-top;
     }
 
+    &__border-right {
+        border-right: 1px solid @block__border-right;
+    }
+
     &__border-bottom {
         border-bottom: 1px solid @block__border-bottom;
     }
 
     &__border-left {
         border-left: 1px solid @block__border-left;
-    }
-
-    &__border-right {
-        border-right: 1px solid @block__border-right;
     }
 
     &__border {

--- a/src/cf-layout.less
+++ b/src/cf-layout.less
@@ -1272,13 +1272,14 @@
     }
 
     &__flush {
-        margin-top: 0 !important;
-        margin-bottom: 0 !important;
-        margin-right: -(@grid_gutter-width / 2);
         margin-left: -(@grid_gutter-width / 2);
+        margin-top: 0 !important;
+        margin-right: -(@grid_gutter-width / 2);
+        margin-bottom: 0 !important;
+
         .respond-to-min(600px, {
-          margin-right: -@grid_gutter-width;
-          margin-left: -@grid_gutter-width;
+            margin-right: -@grid_gutter-width;
+            margin-left: -@grid_gutter-width;
         });
     }
 

--- a/src/cf-layout.less
+++ b/src/cf-layout.less
@@ -1335,10 +1335,10 @@
     }
 
     &__flush {
-        margin-left: -(@grid_gutter-width / 2);
         margin-top: 0 !important;
         margin-right: -(@grid_gutter-width / 2);
         margin-bottom: 0 !important;
+        margin-left: -(@grid_gutter-width / 2);
 
         .respond-to-min(600px, {
             margin-right: -@grid_gutter-width;


### PR DESCRIPTION
Updates to add flush and border modifiers, plus code cleanup.
## Additions
- Added `.block__flush` modifier for removing margin from all sides of a `.block`. Equivalent to `.block .block__flush-top .block__flush-bottom .block__flush-sides`.
- Added `.block__border-left`, `.block__border-right`, and `.block__border` modifiers to control all border settings.
## Changes
- Changed bottom-padding of `.block__bg` to be double its current amount. Ems-equivalent of 30px on top and 60px on bottom.
- Removed extraneous whitespace.
- Changed order of block modifier docs to fit order of CSS classes.
## Review
- @Scotchester 
- @jimmynotjim 
- @sebworks 
- @KimberlyMunoz 
## Todos
- https://github.com/cfpb/cfgov-refresh/blob/flapjack/cfgov/v1/preprocessed/css/cf-enhancements.less#L1199-L1300 can be removed after merging and updating this in V1.
